### PR TITLE
Add Italian

### DIFF
--- a/05.json
+++ b/05.json
@@ -32,12 +32,12 @@
   "errorMetadataNullName": "Un Nome di un payload risulta NULL",
   "errorMetadataMissingPayloadFile": "Impossibile trovare un payload",
 
-  "errorNoPayloads": "Non sono presenti payloads disponibili :(",
+  "errorNoPayloads": "Nessun payload disponibile :(",
 
   "errorShellcodeOpen": "Impossibile aprire: %s",
   "errorShellcodeMmap": "Unable to mmap payload",
   "errorShellcodeMprotect": "Unable to mprotect payload",
   "errorShellcodeMunmap": "Failed to munmap payload",
 
-  "creditsText": ""
+  "creditsText": "Victorbry99"
 }

--- a/05.json
+++ b/05.json
@@ -32,7 +32,7 @@
   "errorMetadataNullName": "Un Nome di un payload risulta NULL",
   "errorMetadataMissingPayloadFile": "Impossibile trovare un payload",
 
-  "errorNoPayloads": "Non sono presenti payload disponibili :(",
+  "errorNoPayloads": "Non sono presenti payloads disponibili :(",
 
   "errorShellcodeOpen": "Impossibile aprire: %s",
   "errorShellcodeMmap": "Unable to mmap payload",

--- a/05.json
+++ b/05.json
@@ -1,0 +1,43 @@
+{
+  "mainTitle": "Payload Guest",
+  "creditsTitle": "Credits",
+
+  "loadingTick1": "Caricamento.",
+  "loadingTick2": "Caricamento..",
+  "loadingTick3": "Caricamento...",
+
+  "ok": "Ok",
+  "select": "Seleziona",
+  "refresh": "Refresh",
+  "credits": "Credits",
+  "return": "Indietro",
+
+  "pageIndicator": "Pagina %i / %i",
+
+  "errorFatal": "ERRORE FATALE!",
+  "errorCloseApplication": "È pregato di chiudere l' Applicazione.",
+  "errorLoadLibjbc": "Impossibile caricare libjbc.prx",
+  "errorInitializeLibjbc": "Impossibile inizializzare libjbc",
+  "errorJailbreak": "Jailbreak non riuscito",
+
+  "errorPathOutput": "Path: %s",
+  "errorIndexOutput": "Index: #%zu",
+  "errorHexOutput": "Error: 0x%08x",
+
+  "errorMetadata": "Metadata Error",
+  "errorMetadataRead": "Impossibile aprire o leggere `meta.json`",
+  "errorMetadataMalformed": "`meta.json` inadeguato",
+  "errorMetadataMissingName": "Un Nome di un payload è assente",
+  "errorMetadataMissingFilename": "Un Filename di un payload è assente",
+  "errorMetadataNullName": "Un Nome di un payload risulta NULL",
+  "errorMetadataMissingPayloadFile": "Impossibile trovare un payload",
+
+  "errorNoPayloads": "Non sono presenti payload disponibili :(",
+
+  "errorShellcodeOpen": "Impossibile aprire: %s",
+  "errorShellcodeMmap": "Unable to mmap payload",
+  "errorShellcodeMprotect": "Unable to mprotect payload",
+  "errorShellcodeMunmap": "Failed to munmap payload",
+
+  "creditsText": ""
+}


### PR DESCRIPTION
Ho lasciato alcune delle frasi non tradotte perchè non vengone bene in italiano e sono termini che comunque utilizziamo anche noi come credits, Path o il tititolo che secondo me non va tradotto. Anche alcuni errori utili solo ai devs li ho lasciati in inglese per 2 motivi : 1 vengono malissimo tradotti. 2 le segnalazioni ad AlAzif in caso di problemi  saranno più comprensibili.
Se qualcuno ha un idea migliore o vuole migliorare le traduzioni è benvenuto a discuterne qui:)
